### PR TITLE
add a note to the README concerning /boot/config.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Options:
 The following command will track between all faces in a frame. Supports Edge TPU acceleration by passing the `--edge-tpu` option.
 
 ```
-rpi-deep-pantilt face-detect --help
-Usage: cli.py face-detect [OPTIONS]
+rpi-deep-pantilt face-track --help
+Usage: cli.py face-track [OPTIONS]
 
 Options:
   --loglevel TEXT  Run object detection without pan-tilt controls. Pass

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ pip install https://github.com/leigh-johnson/Tensorflow-bin/blob/master/tensorfl
 pip install rpi-deep-pantilt
 ```
 
+4. Raspberry 4 users running Rasberian Buster might have to edit /boot/config.txt and uncomment the following lines
+
+```bash
+dtparam=i2c1=on
+dtparam=i2c_arm=on
+```
+if they see an error running 
+
+```bash
+$ rpi-deep-pantilt test pantilt
+```
+similar to :
+
+```bash
+  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/pantilthat/pantilt.py", line 72, in setup
+    self._i2c = SMBus(1)
+FileNotFoundError: [Errno 2] No such file or directory
+```
+Source: https://github.com/ankitaggarwal011/PiScope/issues/3#issuecomment-166381762
+
 # Example Usage
 
 ## Object Detection


### PR DESCRIPTION
I edited the README to include a fix for an edge case a user might experience on a Raspberry 4 and following the [Medium](https://towardsdatascience.com/real-time-object-tracking-with-tensorflow-raspberry-pi-and-pan-tilt-hat-2aeaef47e134) article tutorial.

I followed the steps in Medium article, I ran into issues on Raspberry Pi 4 running Rasberian (Feb 2020). After initializing the python virtual env and running "rpi-deep-pantilt test pantilt" I received the error noted below.  This [Github comment](https://github.com/ankitaggarwal011/PiScope/issues/3#issuecomment-166381762) helped to resolve the issue. 

rpi-deep-pantilt test pantilt
INFO:root:Starting Pan-Tilt HAT test!
INFO:root:Pan-Tilt HAT should follow a smooth sine wave
Traceback (most recent call last):
  File "/home/pi/projects/rpi-deep-pantilt/.venv/bin/rpi-deep-pantilt", line 8, in <module>
    sys.exit(main())
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/rpi_deep_pantilt/cli.py", line 153, in main
    cli()
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/rpi_deep_pantilt/cli.py", line 141, in pantilt
    return pantilt_test()
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/rpi_deep_pantilt/control/hardware_test.py", line 38, in pantilt_test
    pantilthat.pan(a)
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/pantilthat/pantilt.py", line 466, in servo_one
    self.setup()
  File "/home/pi/projects/rpi-deep-pantilt/.venv/lib/python3.7/site-packages/pantilthat/pantilt.py", line 72, in setup
    self._i2c = SMBus(1)
FileNotFoundError: [Errno 2] No such file or directory
