### PR TITLE
Use Coral edgetpu tflite_runtime.lite.Interpreter class instead of tensorflow.lite.Interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ $ pip install https://github.com/leigh-johnson/Tensorflow-bin/releases/download/
 pip install rpi-deep-pantilt
 ```
 
+7. Install Coral Edge TPU `tflite_runtime` (optional)
+
+NOTE: This step is only required if you are using [Coral's Edge TPU USB Accelerator](https://coral.withgoogle.com/products/accelerator). If you would like to run TFLite inferences using CPU only, skip this step. 
+
+```bash
+$ pip install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl
+```
+
 =======
 # Configuration
 

--- a/rpi_deep_pantilt/detect/facessd_mobilenet_v2.py
+++ b/rpi_deep_pantilt/detect/facessd_mobilenet_v2.py
@@ -2,6 +2,7 @@
 import logging
 import pathlib
 import os
+import sys
 
 # lib
 import numpy as np
@@ -11,7 +12,6 @@ import tensorflow as tf
 from rpi_deep_pantilt import __path__ as rpi_deep_pantilt_path
 from rpi_deep_pantilt.detect.util.label import create_category_index_from_labelmap
 from rpi_deep_pantilt.detect.util.visualization import visualize_boxes_and_labels_on_image_array
-
 
 
 class FaceSSD_MobileNet_V2_EdgeTPU(object):
@@ -45,9 +45,18 @@ class FaceSSD_MobileNet_V2_EdgeTPU(object):
 
         self.model_path = os.path.splitext(
             os.path.splitext(self.model_dir)[0]
-         )[0] + f'/{self.tflite_model_file}'
+        )[0] + f'/{self.tflite_model_file}'
 
-        self.tflite_interpreter = tf.lite.Interpreter(
+        try:
+            from tflite_runtime import interpreter as coral_tflite_interpreter
+        except ImportError as e:
+            logging.error(e)
+            logging.error('Please install Edge TPU tflite_runtime:')
+            logging.error(
+                '$ pip install 	https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl')
+            sys.exit(1)
+
+        self.tflite_interpreter = coral_tflite_interpreter.Interpreter(
             model_path=self.model_path,
             experimental_delegates=[
                 tf.lite.experimental.load_delegate(self.EDGETPU_SHARED_LIB)
@@ -171,6 +180,7 @@ class FaceSSD_MobileNet_V2_EdgeTPU(object):
             'num_detections': len(num_detections)
         }
 
+
 class FaceSSD_MobileNet_V2(object):
 
     PATH_TO_LABELS = rpi_deep_pantilt_path[0] + '/data/facessd_label_map.pbtxt'
@@ -197,9 +207,9 @@ class FaceSSD_MobileNet_V2(object):
             cache_subdir='models'
         )
 
-        self.model_path =  os.path.splitext(
+        self.model_path = os.path.splitext(
             os.path.splitext(self.model_dir)[0]
-         )[0] + '/model_postprocessed.tflite'
+        )[0] + '/model_postprocessed.tflite'
 
         self.tflite_interpreter = tf.lite.Interpreter(
             model_path=self.model_path,

--- a/rpi_deep_pantilt/detect/ssd_mobilenet_v3_coco.py
+++ b/rpi_deep_pantilt/detect/ssd_mobilenet_v3_coco.py
@@ -2,6 +2,7 @@
 import logging
 import pathlib
 import os
+import sys
 
 # lib
 import numpy as np
@@ -44,9 +45,18 @@ class SSDMobileNet_V3_Coco_EdgeTPU_Quant(object):
 
         self.model_path = os.path.splitext(
             os.path.splitext(self.model_dir)[0]
-         )[0] + f'/{self.tflite_model_file}'
+        )[0] + f'/{self.tflite_model_file}'
 
-        self.tflite_interpreter = tf.lite.Interpreter(
+        try:
+            from tflite_runtime import interpreter as coral_tflite_interpreter
+        except ImportError as e:
+            logging.error(e)
+            logging.error('Please install Edge TPU tflite_runtime:')
+            logging.error(
+                '$ pip install 	https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl')
+            sys.exit(1)
+
+        self.tflite_interpreter = coral_tflite_interpreter.Interpreter(
             model_path=self.model_path,
             experimental_delegates=[
                 tf.lite.experimental.load_delegate(self.EDGETPU_SHARED_LIB)
@@ -197,9 +207,9 @@ class SSDMobileNet_V3_Small_Coco_PostProcessed(object):
             cache_subdir='models'
         )
 
-        self.model_path =  os.path.splitext(
+        self.model_path = os.path.splitext(
             os.path.splitext(self.model_dir)[0]
-         )[0] + '/model_postprocessed.tflite'
+        )[0] + '/model_postprocessed.tflite'
 
         self.tflite_interpreter = tf.lite.Interpreter(
             model_path=self.model_path,


### PR DESCRIPTION
To use Coral Edge TPU's Python API, you must use their bundled `Interpreter` and `Delegate` base classes as well. I think these SWIG wrappers are probably built and linked against a specific TensorFlow commit. 

Using libedgetpu.so with tensorflow.lite.Interpreter, results in an error that's almost certainly raised by an incorrect SWIG  typemap. 

`Unsupported data type in custom op handler: 0Node number 2 (EdgeTpuDelegateForCustomOp)`

If edgetpu contributors are accepting patches, continue troubleshooting by grepping through a diff of all typemap revisions between the commit libedgetpu.so is linked against and the current 2.2.0 TensorFlow release.

closes #13
link https://github.com/google-coral/edgetpu/issues/124

